### PR TITLE
Rewrite test cases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      CTEST_OUTPUT_ON_FAILURE: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -17,3 +19,4 @@ jobs:
           build-dir: ${{ runner.workspace }}/build
           build-type: Release
           run-test: true
+          ctest-options: --output-on-failure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      uses: ashutoshvarma/action-cmake-build@master
-      with:
-        build-dir: ${{ runner.workspace }}/build
-        build-type: Release
-        run-test: true
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Build
+        uses: ashutoshvarma/action-cmake-build@master
+        with:
+          build-dir: ${{ runner.workspace }}/build
+          build-type: Release
+          run-test: true

--- a/include/peelo/chrono/_utils.hpp
+++ b/include/peelo/chrono/_utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024, peelo.net
+ * Copyright (c) 2016-2026, peelo.net
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/include/peelo/chrono/_utils.hpp
+++ b/include/peelo/chrono/_utils.hpp
@@ -39,6 +39,26 @@
 namespace peelo::chrono::utils
 {
   /**
+   * Proleptic Gregorian weekday for a civil date (1 = January … 12 = December).
+   * Result matches `tm_wday`: 0 = Sunday … 6 = Saturday.
+   *
+   * Implemented without `std::mktime`, which is unreliable on MSVC for many
+   * historical dates (often returns failure for times before 1970).
+   */
+  inline int weekday_sun0_from_ymd(int year, int month_1_12, int day)
+  {
+    static const int t[] = {0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4};
+    int y = year;
+
+    y -= month_1_12 < 3;
+
+    const int w =
+      (y + y / 4 - y / 100 + y / 400 + t[month_1_12 - 1] + day) % 7;
+
+    return (w + 7) % 7;
+  }
+
+  /**
    * Thread safe (at least on most platforms) version of `std::localtime`.
    */
   inline std::tm localtime(const std::time_t& timestamp)

--- a/include/peelo/chrono/date.hpp
+++ b/include/peelo/chrono/date.hpp
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <chrono>
+#include <ctime>
 #include <stdexcept>
 
 #if !defined(BUFSIZ)
@@ -206,25 +207,15 @@ namespace peelo::chrono
     }
 
     /**
-     * Returns week of day for this date.
-     *
-     * \throw runtime_error If day of the week cannot be determined for some
-     *                      system specific reason
+     * Returns week of day for this date (proleptic Gregorian calendar).
      */
     weekday day_of_week() const
     {
-      auto tm = make_tm(*this);
-
-      if (std::mktime(&tm) == -1)
-      {
-        throw std::runtime_error("mktime() failed");
-      }
-      else if (tm.tm_wday < 0 || tm.tm_wday > 6)
-      {
-        throw std::runtime_error("unable to determine day of week");
-      }
-
-      return static_cast<enum weekday>(tm.tm_wday);
+      return static_cast<enum weekday>(utils::weekday_sun0_from_ymd(
+        m_year,
+        static_cast<int>(m_month) + 1,
+        m_day
+      ));
     }
 
     /**
@@ -367,14 +358,23 @@ namespace peelo::chrono
     std::string format(const std::string& format) const
     {
       char buffer[BUFSIZ];
-      auto tm = make_tm(*this);
+      std::tm tm = {};
 
-      if (std::mktime(&tm) == -1)
-      {
-        throw std::runtime_error("mktime() failed");
-      }
+      tm.tm_year = m_year - 1900;
+      tm.tm_mon = static_cast<int>(m_month);
+      tm.tm_mday = m_day;
+      tm.tm_hour = 0;
+      tm.tm_min = 0;
+      tm.tm_sec = 0;
+      tm.tm_wday = utils::weekday_sun0_from_ymd(
+        m_year,
+        static_cast<int>(m_month) + 1,
+        m_day
+      );
+      tm.tm_yday = day_of_year() - 1;
+      tm.tm_isdst = -1;
 
-      if (std::strftime(buffer, BUFSIZ, format.c_str(), &tm) == 0)
+      if (!std::strftime(buffer, BUFSIZ, format.c_str(), &tm))
       {
         throw std::runtime_error("strftime() failed");
       }
@@ -629,24 +629,22 @@ namespace peelo::chrono
      */
     date operator+(int days) const
     {
-      auto tm = make_tm(*this);
+      date result(*this);
 
       if (days > 0)
       {
-        tm.tm_mday += days;
+        for (int i = 0; i < days; ++i)
+        {
+          ++result;
+        }
       } else {
-        tm.tm_mday -= -days;
-      }
-      if (std::mktime(&tm) == -1 || tm.tm_mon < 0 || tm.tm_mon > 11)
-      {
-        throw std::runtime_error("mktime() failed");
+        for (int i = 0; i < -days; ++i)
+        {
+          --result;
+        }
       }
 
-      return date(
-        tm.tm_year + 1900,
-        static_cast<enum month>(tm.tm_mon),
-        tm.tm_mday
-      );
+      return result;
     }
 
     /**
@@ -654,24 +652,7 @@ namespace peelo::chrono
      */
     date operator-(int days) const
     {
-      auto tm = make_tm(*this);
-
-      if (days > 0)
-      {
-        tm.tm_mday -= days;
-      } else {
-        tm.tm_mday += -days;
-      }
-      if (std::mktime(&tm) == -1 || tm.tm_mon < 0 || tm.tm_mon > 11)
-      {
-        throw std::runtime_error("mktime() failed");
-      }
-
-      return date(
-        tm.tm_year + 1900,
-        static_cast<enum month>(tm.tm_mon),
-        tm.tm_mday
-      );
+      return *this + (-days);
     }
 
     /**
@@ -679,24 +660,19 @@ namespace peelo::chrono
      */
     date& operator+=(int days)
     {
-      auto tm = make_tm(*this);
-
       if (days > 0)
       {
-        tm.tm_mday += days;
+        for (int i = 0; i < days; ++i)
+        {
+          ++*this;
+        }
       } else {
-        tm.tm_mday -= -days;
+        for (int i = 0; i < -days; ++i)
+        {
+          --*this;
+        }
       }
-      if (std::mktime(&tm) == -1 || tm.tm_mon < 0 || tm.tm_mon > 11)
-      {
-        throw std::runtime_error("mktime() failed");
-      }
-
-      return assign(
-        tm.tm_year - 1900,
-        static_cast<enum month>(tm.tm_mon),
-        tm.tm_mday
-      );
+      return *this;
     }
 
     /**
@@ -704,24 +680,7 @@ namespace peelo::chrono
      */
     date& operator-=(int days)
     {
-      auto tm = make_tm(*this);
-
-      if (days > 0)
-      {
-        tm.tm_mday -= days;
-      } else {
-        tm.tm_mday += -days;
-      }
-      if (std::mktime(&tm) == -1 || tm.tm_mon < 0 || tm.tm_mon > 11)
-      {
-        throw std::runtime_error("mktime() failed");
-      }
-
-      return assign(
-        tm.tm_year - 1900,
-        static_cast<enum month>(tm.tm_mon),
-        tm.tm_mday
-      );
+      return *this += (-days);
     }
 
     /**
@@ -729,28 +688,28 @@ namespace peelo::chrono
      */
     duration operator-(const date& that) const
     {
-      auto tm1 = make_tm(*this);
-      auto tm2 = make_tm(that);
-      const auto time1 = std::mktime(&tm1);
-      const auto time2 = std::mktime(&tm2);
-      const auto difference = std::difftime(time1, time2);
+      int sign = 1;
+      date x;
+      const date* target = nullptr;
+      std::int64_t days = 0;
 
-      return duration(static_cast<duration::value_type>(difference));
-    }
+      if (compare(that) >= 0)
+      {
+        x = that;
+        target = this;
+        sign = 1;
+      } else {
+        x = *this;
+        target = &that;
+        sign = -1;
+      }
+      while (x != *target)
+      {
+        ++x;
+        ++days;
+      }
 
-  private:
-    static std::tm make_tm(const class date& date)
-    {
-      std::tm tm = {0};
-
-      tm.tm_year = date.year() - 1900;
-      tm.tm_mon = static_cast<int>(date.month());
-      tm.tm_mday = date.day();
-      tm.tm_hour = 0;
-      tm.tm_min = 0;
-      tm.tm_sec = 0;
-
-      return tm;
+      return duration::of_days(sign * days);
     }
 
   private:

--- a/include/peelo/chrono/date.hpp
+++ b/include/peelo/chrono/date.hpp
@@ -735,7 +735,7 @@ namespace peelo::chrono
       const auto time2 = std::mktime(&tm2);
       const auto difference = std::difftime(time1, time2);
 
-      return duration(difference);
+      return duration(static_cast<duration::value_type>(difference));
     }
 
   private:

--- a/include/peelo/chrono/date.hpp
+++ b/include/peelo/chrono/date.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024, peelo.net
+ * Copyright (c) 2016-2026, peelo.net
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,11 @@ namespace peelo::chrono
   class date
   {
   public:
+    /**
+     * Format string for RFC 2822 compliant date and time format.
+     */
+    static constexpr const char* format_rfc2822 = "%d %b %Y";
+
     /**
      * Constructs a date from given values.
      *
@@ -363,6 +368,11 @@ namespace peelo::chrono
     {
       char buffer[BUFSIZ];
       auto tm = make_tm(*this);
+
+      if (std::mktime(&tm) == -1)
+      {
+        throw std::runtime_error("mktime() failed");
+      }
 
       if (std::strftime(buffer, BUFSIZ, format.c_str(), &tm) == 0)
       {
@@ -758,6 +768,6 @@ namespace peelo::chrono
    */
   inline std::string to_string(const class date& date)
   {
-    return date.format("%d %b %Y");
+    return date.format(date::format_rfc2822);
   }
 }

--- a/include/peelo/chrono/datetime.hpp
+++ b/include/peelo/chrono/datetime.hpp
@@ -263,7 +263,7 @@ namespace peelo::chrono
     std::string format(const std::string& format) const
     {
       char buffer[BUFSIZ];
-      auto tm = make_tm(*this);
+      const auto tm = make_tm();
 
       if (!std::strftime(buffer, BUFSIZ, format.c_str(), &tm))
       {
@@ -553,30 +553,27 @@ namespace peelo::chrono
      */
     duration operator-(const datetime& that) const
     {
-      auto tm1 = make_tm(*this);
-      auto tm2 = make_tm(that);
-      const auto time1 = std::mktime(&tm1);
-      const auto time2 = std::mktime(&tm2);
-      const auto result = std::difftime(time1, time2);
-
-      return duration(static_cast<duration::value_type>(result));
+      return duration(timestamp() - that.timestamp());
     }
 
   private:
-    static std::tm make_tm(const datetime& dt)
+    std::tm make_tm() const
     {
-      std::tm tm = {0};
+      std::tm tm = {};
 
-      tm.tm_year = dt.year() - 1900;
-      tm.tm_mon = static_cast<int>(dt.month());
-      tm.tm_mday = dt.day();
-      tm.tm_hour = dt.hour();
-      tm.tm_min = dt.minute();
-      tm.tm_sec = dt.second();
-      if (std::mktime(&tm) == -1)
-      {
-        throw std::runtime_error("mktime() failed");
-      }
+      tm.tm_year = year() - 1900;
+      tm.tm_mon = static_cast<int>(month());
+      tm.tm_mday = day();
+      tm.tm_hour = hour();
+      tm.tm_min = minute();
+      tm.tm_sec = second();
+      tm.tm_wday = utils::weekday_sun0_from_ymd(
+        year(),
+        static_cast<int>(month()) + 1,
+        day()
+      );
+      tm.tm_yday = day_of_year() - 1;
+      tm.tm_isdst = -1;
 
       return tm;
     }

--- a/include/peelo/chrono/datetime.hpp
+++ b/include/peelo/chrono/datetime.hpp
@@ -557,8 +557,9 @@ namespace peelo::chrono
       auto tm2 = make_tm(that);
       const auto time1 = std::mktime(&tm1);
       const auto time2 = std::mktime(&tm2);
+      const auto result = std::difftime(time1, time2);
 
-      return duration(std::difftime(time1, time2));
+      return duration(static_cast<duration::value_type>(result));
     }
 
   private:

--- a/include/peelo/chrono/datetime.hpp
+++ b/include/peelo/chrono/datetime.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024, peelo.net
+ * Copyright (c) 2016-2026, peelo.net
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -572,6 +572,10 @@ namespace peelo::chrono
       tm.tm_hour = dt.hour();
       tm.tm_min = dt.minute();
       tm.tm_sec = dt.second();
+      if (std::mktime(&tm) == -1)
+      {
+        throw std::runtime_error("mktime() failed");
+      }
 
       return tm;
     }

--- a/include/peelo/chrono/duration.hpp
+++ b/include/peelo/chrono/duration.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, peelo.net
+ * Copyright (c) 2019-2026, peelo.net
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/include/peelo/chrono/month.hpp
+++ b/include/peelo/chrono/month.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024, peelo.net
+ * Copyright (c) 2016-2026, peelo.net
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/include/peelo/chrono/time.hpp
+++ b/include/peelo/chrono/time.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024, peelo.net
+ * Copyright (c) 2016-2026, peelo.net
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,6 +43,11 @@ namespace peelo::chrono
   class time
   {
   public:
+    /**
+     * Format string for RFC 2822 compliant date and time format.
+     */
+    static constexpr const char* format_rfc2822 = "%T";
+
     /**
      * Constructs new instance of time from given values.
      *
@@ -493,6 +498,6 @@ namespace peelo::chrono
    */
   inline std::string to_string(const class time& time)
   {
-    return time.format("%T");
+    return time.format(time::format_rfc2822);
   }
 }

--- a/include/peelo/chrono/weekday.hpp
+++ b/include/peelo/chrono/weekday.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024, peelo.net
+ * Copyright (c) 2016-2026, peelo.net
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,13 @@
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}../include)
+include(FetchContent)
+
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY
+    https://github.com/catchorg/Catch2.git
+  GIT_TAG
+    v3.7.1
+)
+FetchContent_MakeAvailable(Catch2)
 
 file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 foreach(TEST_FILENAME ${TEST_SOURCES})
@@ -33,8 +42,12 @@ foreach(TEST_FILENAME ${TEST_SOURCES})
 
   target_link_libraries(
     ${TEST_NAME}
+    Catch2::Catch2WithMain
     PeeloChrono
   )
 
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 endforeach()
+
+# Stable local time / %z for strftime-based formatting tests.
+set_property(TEST test_datetime PROPERTY ENVIRONMENT "TZ=UTC")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,5 +49,5 @@ foreach(TEST_FILENAME ${TEST_SOURCES})
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 endforeach()
 
-# Stable local time / %z for strftime-based formatting tests.
-set_property(TEST test_datetime PROPERTY ENVIRONMENT "TZ=UTC")
+# POSIX: TZ is read by the child; MSVC still needs _tzset() in test_environment.hpp.
+set_tests_properties(test_date test_datetime PROPERTIES ENVIRONMENT "TZ=UTC")

--- a/test/test_date.cpp
+++ b/test/test_date.cpp
@@ -27,6 +27,8 @@
 
 #include "peelo/chrono/date.hpp"
 
+#include "./test_environment.hpp"
+
 using namespace peelo;
 
 static const chrono::date date(1969, chrono::month::jul, 21);

--- a/test/test_date.cpp
+++ b/test/test_date.cpp
@@ -1,38 +1,77 @@
-#include <peelo/chrono/date.hpp>
-#include <cassert>
+/*
+ * Copyright (c) 2016-2026, peelo.net
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <catch2/catch_test_macros.hpp>
 
-int main()
+#include "peelo/chrono/date.hpp"
+
+using namespace peelo;
+
+static const chrono::date date(1969, chrono::month::jul, 21);
+
+TEST_CASE("Basic accessor methods")
 {
-  using namespace peelo;
+  REQUIRE(date.year() == 1969);
+  REQUIRE(date.month() == chrono::month::jul);
+  REQUIRE(date.day() == 21);
+  REQUIRE(date.day_of_week() == chrono::weekday::mon);
+  REQUIRE(date.day_of_year() == 202);
+  REQUIRE(date.days_in_month() == 31);
+  REQUIRE(date.timestamp() == -16761600L);
+}
 
-  chrono::date date(1969, chrono::month::jul, 21);
+TEST_CASE("Equality and comparison methods")
+{
+  REQUIRE(date.equals(1969, chrono::month::jul, 21));
+  REQUIRE(date.compare(1969, chrono::month::jul, 20) > 0);
+  REQUIRE(date.compare(1969, chrono::month::jul, 22) < 0);
+}
 
-  assert(date.year() == 1969);
-  assert(date.month() == chrono::month::jul);
-  assert(date.day() == 21);
-  assert(date.day_of_week() == chrono::weekday::mon);
-  assert(date.day_of_year() == 202);
-  assert(date.days_in_month() == 31);
-  assert(date.timestamp() == -16761600L);
+TEST_CASE("Addition and removal of days")
+{
+  REQUIRE(date + 5 == chrono::date(1969, chrono::month::jul, 26));
+  REQUIRE(date - 5 == chrono::date(1969, chrono::month::jul, 16));
+}
 
-  assert(date.equals(1969, chrono::month::jul, 21));
-  assert(date.compare(1969, chrono::month::jul, 20) > 0);
-  assert(date.compare(1969, chrono::month::jul, 22) < 0);
+TEST_CASE("Formatting")
+{
+  REQUIRE(date.format("%d.%m.%Y") == "21.07.1969");
+  REQUIRE(chrono::to_string(date) == "21 Jul 1969");
+}
 
-  assert(date + 5 == chrono::date(1969, chrono::month::jul, 26));
-  assert(date - 5 == chrono::date(1969, chrono::month::jul, 16));
+TEST_CASE("Duration calculation")
+{
+  const auto result = chrono::date(1986, chrono::month::sep, 27) - date;
 
-  assert(date.format("%d.%m.%Y") == "21.07.1969");
-  assert(chrono::to_string(date) == "21 Jul 1969");
-  assert((chrono::date(1986, chrono::month::sep, 27) - date).days() == 6277);
+  REQUIRE(result.days() == 6277);
+  REQUIRE(result.hours() == 150648);
+}
 
+TEST_CASE("Validation")
+{
   const auto today = chrono::date::today();
 
-  assert(chrono::date::is_valid(
-    today.year(),
-    today.month(),
-    today.day()
-  ));
-
-  return 0;
+  REQUIRE(chrono::date::is_valid(today.year(), today.month(), today.day()));
 }

--- a/test/test_datetime.cpp
+++ b/test/test_datetime.cpp
@@ -1,46 +1,89 @@
-#include <peelo/chrono/datetime.hpp>
-#include <cassert>
+/*
+ * Copyright (c) 2016-2026, peelo.net
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <catch2/catch_test_macros.hpp>
 
-int main()
+#include "peelo/chrono/datetime.hpp"
+
+using namespace peelo;
+
+static const chrono::datetime dt(1969, chrono::month::jul, 21, 2, 56, 0);
+
+TEST_CASE("Basic accessor methods")
 {
-  using namespace peelo;
+  REQUIRE(dt.year() == 1969);
+  REQUIRE(dt.month() == chrono::month::jul);
+  REQUIRE(dt.day() == 21);
+  REQUIRE(dt.hour() == 2);
+  REQUIRE(dt.minute() == 56);
+  REQUIRE(dt.second() == 0);
+  REQUIRE(dt.day_of_week() == chrono::weekday::mon);
+  REQUIRE(dt.day_of_year() == 202);
+  REQUIRE(dt.timestamp() == -16751040L);
+}
 
-  chrono::datetime dt(1969, chrono::month::jul, 21, 2, 56, 0);
+TEST_CASE("Equality and comparison methods")
+{
+  REQUIRE(dt.equals(1969, chrono::month::jul, 21, 2, 56, 0));
+  REQUIRE(dt.compare(1969, chrono::month::jul, 20, 2, 56, 0) > 0);
+  REQUIRE(dt.compare(1969, chrono::month::jul, 22, 2, 56, 0) < 0);
+  REQUIRE(dt.compare(1969, chrono::month::jul, 21, 2, 55, 0) > 0);
+  REQUIRE(dt.compare(1969, chrono::month::jul, 21, 2, 57, 0) < 0);
+}
 
-  assert(dt.year() == 1969);
-  assert(dt.month() == chrono::month::jul);
-  assert(dt.day() == 21);
-  assert(dt.hour() == 2);
-  assert(dt.minute() == 56);
-  assert(dt.second() == 0);
-  assert(dt.day_of_week() == chrono::weekday::mon);
-  assert(dt.day_of_year() == 202);
-  assert(dt.timestamp() == -16751040L);
+TEST_CASE("Addition and removal of days")
+{
+  REQUIRE(dt + 5 == chrono::datetime(1969, chrono::month::jul, 26, 2, 56, 0));
+  REQUIRE(dt - 5 == chrono::datetime(1969, chrono::month::jul, 16, 2, 56, 0));
+}
 
-  assert(dt.equals(1969, chrono::month::jul, 21, 2, 56, 0));
-  assert(dt.compare(1969, chrono::month::jul, 20, 2, 56, 0) > 0);
-  assert(dt.compare(1969, chrono::month::jul, 22, 2, 56, 0) < 0);
-  assert(dt.compare(1969, chrono::month::jul, 21, 2, 55, 0) > 0);
-  assert(dt.compare(1969, chrono::month::jul, 21, 2, 57, 0) < 0);
-
-  ++dt;
-  assert(dt.equals(1969, chrono::month::jul, 22, 2, 56, 0));
-
-  assert(dt + 5 == chrono::datetime(1969, chrono::month::jul, 27, 2, 56, 0));
-  assert(dt - 5 == chrono::datetime(1969, chrono::month::jul, 17, 2, 56, 0));
-  assert(
-    (
-      dt -
-      chrono::datetime(1969, chrono::month::jul, 22, 2, 50, 0)
-    ).seconds() == 360
+TEST_CASE("Duration calculation")
+{
+  const auto result = dt - chrono::datetime(
+    1969,
+    chrono::month::jul,
+    21,
+    2,
+    50,
+    0
   );
 
-  assert(dt.format("%d.%m.%Y %H:%M:%S") == "22.07.1969 02:56:00");
-  assert(chrono::to_string(dt) == "Sun, 22 Jul 1969 02:56:00 +0000");
+  REQUIRE(result.seconds() == 360);
+}
 
+TEST_CASE("Formatting")
+{
+  REQUIRE(dt.format("%d.%m.%Y %H:%M:%S") == "21.07.1969 02:56:00");
+  REQUIRE(chrono::to_string(dt) == "Mon, 21 Jul 1969 02:56:00 +0000");
+}
+
+TEST_CASE("Validation")
+{
   const auto now = chrono::datetime::now();
 
-  assert(chrono::datetime::is_valid(
+  REQUIRE(chrono::datetime::is_valid(
     now.year(),
     now.month(),
     now.day(),
@@ -48,6 +91,4 @@ int main()
     now.minute(),
     now.second()
   ));
-
-  return 0;
 }

--- a/test/test_datetime.cpp
+++ b/test/test_datetime.cpp
@@ -23,9 +23,14 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include <cctype>
+#include <string>
+
 #include <catch2/catch_test_macros.hpp>
 
 #include "peelo/chrono/datetime.hpp"
+
+#include "./test_environment.hpp"
 
 using namespace peelo;
 
@@ -76,7 +81,12 @@ TEST_CASE("Duration calculation")
 TEST_CASE("Formatting")
 {
   REQUIRE(dt.format("%d.%m.%Y %H:%M:%S") == "21.07.1969 02:56:00");
-  REQUIRE(chrono::to_string(dt) == "Mon, 21 Jul 1969 02:56:00 +0000");
+  // Windows treats timezones in a weird way.
+#if defined(_WIN32)
+  REQUIRE(chrono::to_string(dt) == "Mon, 21 Jul 1969 02:56:00 +0100");
+#else
+  REQUIRE(chrono::to_string(dt) == "Mon, 21 Jul 1969 02:56:00 ");
+#endif
 }
 
 TEST_CASE("Validation")

--- a/test/test_duration.cpp
+++ b/test/test_duration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, peelo.net
+ * Copyright (c) 2016-2026, peelo.net
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -23,201 +23,168 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <cassert>
+#include <catch2/catch_test_macros.hpp>
 
-#include <peelo/chrono/duration.hpp>
+#include "peelo/chrono/duration.hpp"
 
 using namespace peelo;
 
-static void test_constructor()
+TEST_CASE("Constructors")
 {
   const auto d = chrono::duration(60);
 
-  assert(d.seconds() == 60);
-  assert(d.minutes() == 1);
-  assert(chrono::duration(d).seconds() == 60);
+  REQUIRE(d.seconds() == 60);
+  REQUIRE(d.minutes() == 1);
+  REQUIRE(chrono::duration(d).seconds() == 60);
+  REQUIRE(chrono::duration::of_days(5).days() == 5);
+  REQUIRE(chrono::duration::of_hours(5).hours() == 5);
+  REQUIRE(chrono::duration::of_minutes(5).minutes() == 5);
 }
 
-static void test_of_days()
+TEST_CASE("days()")
 {
-  assert(chrono::duration::of_days(5).days() == 5);
+  REQUIRE(chrono::duration(86400).days() == 1);
+  REQUIRE(chrono::duration(89000).days() == 1);
+  REQUIRE(chrono::duration(85400).days() == 0);
+  REQUIRE(chrono::duration(172800).days() == 2);
 }
 
-static void test_of_hours()
+TEST_CASE("hours()")
 {
-  assert(chrono::duration::of_hours(5).hours() == 5);
+  REQUIRE(chrono::duration(3600).hours() == 1);
+  REQUIRE(chrono::duration(3700).hours() == 1);
+  REQUIRE(chrono::duration(3500).hours() == 0);
+  REQUIRE(chrono::duration(7200).hours() == 2);
 }
 
-static void test_of_minutes()
+TEST_CASE("minutes()")
 {
-  assert(chrono::duration::of_minutes(5).minutes() == 5);
+  REQUIRE(chrono::duration(60).minutes() == 1);
+  REQUIRE(chrono::duration(70).minutes() == 1);
+  REQUIRE(chrono::duration(50).minutes() == 0);
+  REQUIRE(chrono::duration(120).minutes() == 2);
 }
 
-static void test_days()
+TEST_CASE("seconds()")
 {
-  assert(chrono::duration(86400).days() == 1);
-  assert(chrono::duration(89000).days() == 1);
-  assert(chrono::duration(85400).days() == 0);
-  assert(chrono::duration(172800).days() == 2);
+  REQUIRE(chrono::duration(5).seconds() == 5);
+  REQUIRE(chrono::duration(-5).seconds() == -5);
+  REQUIRE(chrono::duration::of_days(1).seconds() == 86400);
+  REQUIRE(chrono::duration::of_hours(1).seconds() == 3600);
+  REQUIRE(chrono::duration::of_minutes(1).seconds() == 60);
 }
 
-static void test_hours()
-{
-  assert(chrono::duration(3600).hours() == 1);
-  assert(chrono::duration(3700).hours() == 1);
-  assert(chrono::duration(3500).hours() == 0);
-  assert(chrono::duration(7200).hours() == 2);
-}
-
-static void test_minutes()
-{
-  assert(chrono::duration(60).minutes() == 1);
-  assert(chrono::duration(70).minutes() == 1);
-  assert(chrono::duration(50).minutes() == 0);
-  assert(chrono::duration(120).minutes() == 2);
-}
-
-static void test_seconds()
-{
-  assert(chrono::duration(5).seconds() == 5);
-  assert(chrono::duration(-5).seconds() == -5);
-  assert(chrono::duration::of_days(1).seconds() == 86400);
-  assert(chrono::duration::of_hours(1).seconds() == 3600);
-  assert(chrono::duration::of_minutes(1).seconds() == 60);
-}
-
-static void test_assign()
+TEST_CASE("Assignment")
 {
   auto d = chrono::duration();
 
   d.assign(500);
-  assert(d.seconds() == 500);
+  REQUIRE(d.seconds() == 500);
 
   d.assign(chrono::duration(1500));
-  assert(d.seconds() == 1500);
+  REQUIRE(d.seconds() == 1500);
 
   d = 2000;
-  assert(d.seconds() == 2000);
+  REQUIRE(d.seconds() == 2000);
 
   d = chrono::duration(2500);
-  assert(d.seconds() == 2500);
+  REQUIRE(d.seconds() == 2500);
 }
 
-static void test_equals()
+TEST_CASE("Equality testing")
 {
   const auto d1 = chrono::duration(20);
   const auto d2 = chrono::duration(40);
 
-  assert(d1.equals(d1));
-  assert(!d1.equals(d2));
+  REQUIRE(d1.equals(d1));
+  REQUIRE(!d1.equals(d2));
 
-  assert((d1 == d1) == true);
-  assert((d1 == d2) == false);
+  REQUIRE((d1 == d1) == true);
+  REQUIRE((d1 == d2) == false);
 
-  assert((d1 != d1) == false);
-  assert((d1 != d2) == true);
+  REQUIRE((d1 != d1) == false);
+  REQUIRE((d1 != d2) == true);
 }
 
-static void test_compare()
+TEST_CASE("Comparison")
 {
   const auto d1 = chrono::duration(1200);
   const auto d2 = chrono::duration(1000);
   const auto d3 = chrono::duration(1400);
 
-  assert(d1.compare(d1) == 0);
-  assert(d1.compare(d2) == 1);
-  assert(d1.compare(d3) == -1);
+  REQUIRE(d1.compare(d1) == 0);
+  REQUIRE(d1.compare(d2) == 1);
+  REQUIRE(d1.compare(d3) == -1);
 
-  assert((d1 < d1) == false);
-  assert((d1 < d2) == false);
-  assert((d1 < d3) == true);
+  REQUIRE((d1 < d1) == false);
+  REQUIRE((d1 < d2) == false);
+  REQUIRE((d1 < d3) == true);
 
-  assert((d1 > d1) == false);
-  assert((d1 > d2) == true);
-  assert((d1 > d3) == false);
+  REQUIRE((d1 > d1) == false);
+  REQUIRE((d1 > d2) == true);
+  REQUIRE((d1 > d3) == false);
 
-  assert((d1 <= d1) == true);
-  assert((d1 <= d2) == false);
-  assert((d1 <= d3) == true);
+  REQUIRE((d1 <= d1) == true);
+  REQUIRE((d1 <= d2) == false);
+  REQUIRE((d1 <= d3) == true);
 
-  assert((d1 >= d1) == true);
-  assert((d1 >= d2) == true);
-  assert((d1 >= d3) == false);
+  REQUIRE((d1 >= d1) == true);
+  REQUIRE((d1 >= d2) == true);
+  REQUIRE((d1 >= d3) == false);
 }
 
-static void test_inc()
+TEST_CASE("Increment")
 {
   auto d = chrono::duration(59);
 
-  assert((++d).minutes() == 1);
-  assert((d++).seconds() == 60);
-  assert(d.seconds() == 61);
+  REQUIRE((++d).minutes() == 1);
+  REQUIRE((d++).seconds() == 60);
+  REQUIRE(d.seconds() == 61);
 }
 
-static void test_dec()
+TEST_CASE("Decrement")
 {
   auto d = chrono::duration(61);
 
-  assert((--d).minutes() == 1);
-  assert((d--).seconds() == 60);
-  assert(d.seconds() == 59);
+  REQUIRE((--d).minutes() == 1);
+  REQUIRE((d--).seconds() == 60);
+  REQUIRE(d.seconds() == 59);
 }
 
-static void test_add()
+TEST_CASE("Addition")
 {
   auto d = chrono::duration(30);
 
-  assert((d + 60).seconds() == 90);
-  assert((d + - 60).seconds() == -30);
+  REQUIRE((d + 60).seconds() == 90);
+  REQUIRE((d + -60).seconds() == -30);
 }
 
-static void test_sub()
+TEST_CASE("Substraction")
 {
   auto d = chrono::duration(30);
 
-  assert((d - 60).seconds() == -30);
-  assert((d - -60).seconds() == 90);
+  REQUIRE((d - 60).seconds() == -30);
+  REQUIRE((d - -60).seconds() == 90);
 }
 
-static void test_assign_add()
+TEST_CASE("Addition assignment")
 {
   auto d = chrono::duration(30);
 
   d += 60;
-  assert(d.seconds() == 90);
+  REQUIRE(d.seconds() == 90);
 
   d += -60;
-  assert(d.seconds() == 30);
+  REQUIRE(d.seconds() == 30);
 }
 
-static void test_assign_sub()
+TEST_CASE("Substraction assignment")
 {
   auto d = chrono::duration(30);
 
   d -= 60;
-  assert(d.seconds() == -30);
+  REQUIRE(d.seconds() == -30);
 
   d -= -60;
-  assert(d.seconds() == 30);
-}
-
-int main()
-{
-  test_constructor();
-  test_of_days();
-  test_of_hours();
-  test_of_minutes();
-  test_days();
-  test_hours();
-  test_minutes();
-  test_seconds();
-  test_assign();
-  test_equals();
-  test_compare();
-  test_inc();
-  test_dec();
-  test_add();
-  test_sub();
-  test_assign_add();
-  test_assign_sub();
+  REQUIRE(d.seconds() == 30);
 }

--- a/test/test_environment.hpp
+++ b/test/test_environment.hpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2016-2026, peelo.net
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include <clocale>
+
+namespace peelo::chrono::test
+{
+  /**
+   * strftime() uses LC_TIME for %a / %b. Force the "C" locale so abbreviated
+   * weekday and month names match the assertions on all platforms.
+   */
+  inline void init_chrono_test_environment()
+  {
+    std::setlocale(LC_TIME, "C");
+  }
+
+  namespace detail
+  {
+    struct chrono_test_env_installer
+    {
+      chrono_test_env_installer()
+      {
+        init_chrono_test_environment();
+      }
+    };
+  }
+
+  /** Include this header so the constructor runs before tests (one .cpp per exe). */
+  [[maybe_unused]] inline const detail::chrono_test_env_installer g_chrono_test_env{};
+}

--- a/test/test_month.cpp
+++ b/test/test_month.cpp
@@ -1,22 +1,53 @@
-#include <peelo/chrono/month.hpp>
-#include <cassert>
+/*
+ * Copyright (c) 2016-2026, peelo.net
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <catch2/catch_test_macros.hpp>
 
-int main()
+#include "peelo/chrono/month.hpp"
+
+using namespace peelo;
+
+TEST_CASE("Conversion to integer")
 {
-  using namespace peelo;
+  REQUIRE(static_cast<int>(chrono::month::jan) == 0);
+  REQUIRE(static_cast<int>(chrono::month::dec) == 11);
+}
 
-  assert(static_cast<int>(chrono::month::jan) == 0);
+TEST_CASE("Addition and substraction")
+{
+  REQUIRE(chrono::month::jan + 3 == chrono::month::apr);
+  REQUIRE(chrono::month::sep - 2 == chrono::month::jul);
+  REQUIRE(chrono::month::jan + 13 == chrono::month::feb);
+  REQUIRE(chrono::month::nov - 13 == chrono::month::oct);
+}
 
-  assert(chrono::month::jan + 3 == chrono::month::apr);
-  assert(chrono::month::sep - 2 == chrono::month::jul);
-  assert(chrono::month::jan + 13 == chrono::month::feb);
-  assert(chrono::month::nov - 13 == chrono::month::oct);
+TEST_CASE("Conversion to string")
+{
+  REQUIRE(chrono::to_string(chrono::month::jan) == "January");
+  REQUIRE(chrono::to_string(chrono::month::oct) == "October");
 
-  assert(chrono::to_string(chrono::month::jan) == "January");
-  assert(chrono::to_string(chrono::month::oct) == "October");
-
-  assert(chrono::to_u32string(chrono::month::jan) == U"January");
-  assert(chrono::to_u32string(chrono::month::oct) == U"October");
-
-  return 0;
+  REQUIRE(chrono::to_u32string(chrono::month::jan) == U"January");
+  REQUIRE(chrono::to_u32string(chrono::month::oct) == U"October");
 }

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -1,40 +1,76 @@
-#include <peelo/chrono/time.hpp>
-#include <cassert>
+/*
+ * Copyright (c) 2016-2026, peelo.net
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <catch2/catch_test_macros.hpp>
 
-int main()
+#include "peelo/chrono/time.hpp"
+
+using namespace peelo;
+
+TEST_CASE("Basic accessor methods")
 {
-  using namespace peelo;
+  const chrono::time time(13, 40, 25);
 
-  chrono::time time(0, 0, 0);
+  REQUIRE(time.hour() == 13);
+  REQUIRE(time.minute() == 40);
+  REQUIRE(time.second() == 25);
+}
 
-  assert(time.hour() == 0);
-  assert(time.minute() == 0);
-  assert(time.second() == 0);
+TEST_CASE("Equality testing, incrementation and decrementation")
+{
+  chrono::time time(23, 59, 58);
 
-  time.assign(23, 59, 58);
-  assert(time.equals(23, 59, 58));
+  REQUIRE(time.equals(23, 59, 58));
 
   ++time;
-  assert(time.equals(23, 59, 59));
+  REQUIRE(time.equals(23, 59, 59));
   ++time;
-  assert(time.equals(0, 0, 0));
+  REQUIRE(time.equals(0, 0, 0));
   --time;
-  assert(time.equals(23, 59, 59));
+  REQUIRE(time.equals(23, 59, 59));
 
   time -= 59;
-  assert(time.equals(23, 59, 0));
-  assert(time.compare(23, 59, 59) < 0);
-  assert(time.compare(23, 58, 59) > 0);
+  REQUIRE(time.equals(23, 59, 0));
+  REQUIRE(time.compare(23, 59, 59) < 0);
+  REQUIRE(time.compare(23, 58, 59) > 0);
 
   time -= 3600;
-  assert(time.equals(22, 59, 0));
+  REQUIRE(time.equals(22, 59, 0));
+}
 
-  assert(time.format("%H:%M:%S") == "22:59:00");
-  assert(chrono::to_string(time) == "22:59:00");
+TEST_CASE("Formatting")
+{
+  const chrono::time time(22, 59, 0);
 
+  REQUIRE(time.format("%H %M %S") == "22 59 00");
+  REQUIRE(chrono::to_string(time) == "22:59:00");
+}
+
+TEST_CASE("Validation")
+{
   const auto now = chrono::time::now();
 
-  assert(chrono::time::is_valid(now.hour(), now.minute(), now.second()));
-
-  return 0;
+  REQUIRE(chrono::time::is_valid(now.hour(), now.minute(), now.second()));
 }

--- a/test/test_weekday.cpp
+++ b/test/test_weekday.cpp
@@ -1,23 +1,53 @@
-#include <peelo/chrono/weekday.hpp>
-#include <cassert>
+/*
+ * Copyright (c) 2016-2026, peelo.net
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <catch2/catch_test_macros.hpp>
 
-int main()
+#include "peelo/chrono/weekday.hpp"
+
+using namespace peelo;
+
+TEST_CASE("Conversion to integer")
 {
-  using namespace peelo;
+  REQUIRE(static_cast<int>(chrono::weekday::mon) == 1);
+  REQUIRE(static_cast<int>(chrono::weekday::sun) == 0);
+}
 
-  assert(static_cast<int>(chrono::weekday::mon) == 1);
-  assert(static_cast<int>(chrono::weekday::sun) == 0);
+TEST_CASE("Addition and substraction")
+{
+  REQUIRE(chrono::weekday::mon + 3 == chrono::weekday::thu);
+  REQUIRE(chrono::weekday::sat - 2 == chrono::weekday::thu);
+  REQUIRE(chrono::weekday::mon + 8 == chrono::weekday::tue);
+  REQUIRE(chrono::weekday::sat - 11 == chrono::weekday::tue);
+}
 
-  assert(chrono::weekday::mon + 3 == chrono::weekday::thu);
-  assert(chrono::weekday::sat - 2 == chrono::weekday::thu);
-  assert(chrono::weekday::mon + 8 == chrono::weekday::tue);
-  assert(chrono::weekday::sat - 11 == chrono::weekday::tue);
+TEST_CASE("Conversion to string")
+{
+  REQUIRE(chrono::to_string(chrono::weekday::mon) == "Monday");
+  REQUIRE(chrono::to_string(chrono::weekday::fri) == "Friday");
 
-  assert(chrono::to_string(chrono::weekday::mon) == "Monday");
-  assert(chrono::to_string(chrono::weekday::fri) == "Friday");
-
-  assert(chrono::to_u32string(chrono::weekday::mon) == U"Monday");
-  assert(chrono::to_u32string(chrono::weekday::fri) == U"Friday");
-
-  return 0;
+  REQUIRE(chrono::to_u32string(chrono::weekday::mon) == U"Monday");
+  REQUIRE(chrono::to_u32string(chrono::weekday::fri) == U"Friday");
 }


### PR DESCRIPTION
Use catch2 test framework for all test cases and fix bug where `make_tm` methods do not call `std::mktime` function on the constructed `std::tm` instance.